### PR TITLE
Adding security and unit tests to Travis/updating deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,16 @@
 language: node_js
 node_js:
-  - "0.10"
-  - "0.11"
-  - "0.12"
-
+  - "9.11.1"
+dist: trusty
+cache: npm
+before_install:
+  - npm i -g npm@6.0.1
+  - npm --version
+branches:
+  only:
+    - master
+env:
+  - TEST_SUITE=test
+  - TEST_SUITE=test-security
+script:
+  - npm run $TEST_SUITE

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: node_js
 node_js:
-  - "9.11.1"
+  - "node"
 dist: trusty
 cache: npm
 before_install:
-  - npm i -g npm@6.0.1
   - npm --version
 branches:
   only:

--- a/package-lock.json
+++ b/package-lock.json
@@ -202,12 +202,6 @@
         "delayed-stream": "~1.0.0"
       }
     },
-    "commander": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
-      "dev": true
-    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -294,19 +288,6 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
-    },
-    "docco": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/docco/-/docco-0.7.0.tgz",
-      "integrity": "sha1-1gblqZDLoFLKHhgDqcWH7O48XDg=",
-      "dev": true,
-      "requires": {
-        "commander": ">= 0.5.2",
-        "fs-extra": ">= 0.6.0",
-        "highlight.js": ">= 8.0.x",
-        "marked": ">= 0.2.7",
-        "underscore": ">= 1.0.0"
-      }
     },
     "ecc-jsbn": {
       "version": "0.1.2",
@@ -437,17 +418,6 @@
         "mime-types": "^2.1.12"
       }
     },
-    "fs-extra": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      }
-    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -503,12 +473,6 @@
         "path-is-absolute": "^1.0.0"
       }
     },
-    "graceful-fs": {
-      "version": "4.1.15",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
-      "dev": true
-    },
     "growl": {
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
@@ -554,12 +518,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "dev": true
-    },
-    "highlight.js": {
-      "version": "9.15.6",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.6.tgz",
-      "integrity": "sha512-zozTAWM1D6sozHo8kqhfYgsac+B+q0PmsjXeyDrYIHHcBN0zTVT66+s2GW1GZv7DbyaROdLXKdabwS/WqPyIdQ==",
       "dev": true
     },
     "http-errors": {
@@ -699,15 +657,6 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
-    "jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -760,12 +709,6 @@
       "requires": {
         "p-defer": "^1.0.0"
       }
-    },
-    "marked": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.6.2.tgz",
-      "integrity": "sha512-LqxwVH3P/rqKX4EKGz7+c2G9r98WeM/SW34ybhgNGhUQNKtf1GmmSkJ6cDGJ/t6tiyae49qRkpyTw2B9HOrgUA==",
-      "dev": true
     },
     "mem": {
       "version": "4.3.0",
@@ -923,9 +866,9 @@
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
     "object-assign": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz",
-      "integrity": "sha1-+DCbCQg7ASYezj73Nz8rV7jdcEI="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-keys": {
       "version": "1.1.1",
@@ -1269,18 +1212,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true
-    },
-    "underscore": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
-      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==",
-      "dev": true
-    },
-    "universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
     },
     "uri-js": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "url": "git://github.com/coinbase/coinbase-node.git"
   },
   "scripts": {
-    "test": "node_modules/.bin/mocha -R spec"
+    "test": "node_modules/.bin/mocha -R spec",
+    "test-security": "npm audit"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,13 +13,12 @@
   "dependencies": {
     "http-errors": "1.7.2",
     "lodash": "4.17.11",
-    "object-assign": "2.0.0",
+    "object-assign": "4.1.1",
     "request": "2.88.0"
   },
   "description": "The Coinbase API for Node.js",
   "devDependencies": {
     "mocha": "6.1.4",
-    "docco": "0.7.0",
     "nock": "10.0.6"
   },
   "directories": {


### PR DESCRIPTION
Adding `npm audit` and `npm run test` to Travis job, removing `docco` (unused), updating `object-assign`